### PR TITLE
feat: add decimal128 support in schema inference and agg handling

### DIFF
--- a/test/create-mongo-tables.sh
+++ b/test/create-mongo-tables.sh
@@ -197,6 +197,13 @@ db.orders.insertMany([
   }
 ]);
 
+// Create collection with Decimal128 values for precision testing
+db.decimal_test.insertMany([
+  { name: 'item1', amount: NumberDecimal('123.45'), category: 'A' },
+  { name: 'item2', amount: NumberDecimal('999.99'), category: 'A' },
+  { name: 'item3', amount: NumberDecimal('50.00'), category: 'B' }
+]);
+
 // Create empty collection for testing (just create the collection, don't insert empty array)
 db.createCollection('empty_collection');
 
@@ -470,7 +477,7 @@ print('Collections: ' + db.getCollectionNames().join(', '));
 
 echo ""
 echo "Test MongoDB database '$MONGO_DB' created successfully!"
-echo "Collections: users, products, orders, empty_collection, type_conflicts, deeply_nested, nested_scalars_test, object_container_test, schema_test_simple, schema_test_nested, schema_test_paths, schema_test_with_id, schema_test_types"
+echo "Collections: users, products, orders, decimal_test, empty_collection, type_conflicts, deeply_nested, nested_scalars_test, object_container_test, schema_test_simple, schema_test_nested, schema_test_paths, schema_test_with_id, schema_test_types"
 echo ""
 
 # Export environment variables for tests

--- a/test/sql/cache/clear_cache.test
+++ b/test/sql/cache/clear_cache.test
@@ -45,7 +45,7 @@ SELECT COUNT(*) FROM information_schema.tables
 WHERE table_catalog = 'test_mongo' 
   AND table_schema = 'duckdb_mongo_test';
 ----
-14
+15
 
 # Query collections again - should use cached data
 query I
@@ -53,7 +53,7 @@ SELECT COUNT(*) FROM information_schema.tables
 WHERE table_catalog = 'test_mongo' 
   AND table_schema = 'duckdb_mongo_test';
 ----
-14
+15
 
 # Get list of collections (this uses cached collection names)
 query T
@@ -62,6 +62,7 @@ WHERE table_catalog = 'test_mongo'
   AND table_schema = 'duckdb_mongo_test'
 ORDER BY table_name;
 ----
+decimal_test
 deeply_nested
 empty_collection
 matrix
@@ -91,7 +92,7 @@ SELECT COUNT(*) FROM information_schema.tables
 WHERE table_catalog = 'test_mongo' 
   AND table_schema = 'duckdb_mongo_test';
 ----
-14
+15
 
 # Verify we get the same collections (proving fresh data was fetched, not stale cache)
 query T
@@ -100,6 +101,7 @@ WHERE table_catalog = 'test_mongo'
   AND table_schema = 'duckdb_mongo_test'
 ORDER BY table_name;
 ----
+decimal_test
 deeply_nested
 empty_collection
 matrix

--- a/test/sql/query/pushdown_comprehensive.test
+++ b/test/sql/query/pushdown_comprehensive.test
@@ -189,5 +189,29 @@ SELECT in_stock, AVG(price) FROM mongo_test.products GROUP BY in_stock ORDER BY 
 false	299.99
 true	514.99
 
+# ============================================================================
+# Decimal128 aggregate tests (Decimal128 infers as DOUBLE)
+# ============================================================================
+
+# Decimal128 fields should be inferred as DOUBLE and support numeric aggregates
+query I
+SELECT COUNT(*) FROM mongo_test.decimal_test;
+----
+3
+
+# SUM on Decimal128 field
+query IR
+SELECT category, SUM(amount) FROM mongo_test.decimal_test GROUP BY category ORDER BY category;
+----
+A	1123.44
+B	50.0
+
+# AVG on Decimal128 field
+query IR
+SELECT category, AVG(amount) FROM mongo_test.decimal_test GROUP BY category ORDER BY category;
+----
+A	561.72
+B	50.0
+
 statement ok
 DETACH mongo_test;


### PR DESCRIPTION
## Summary
This PR adds proper support for MongoDB's Decimal128 type, which is commonly used for financial and high-precision numeric data.

**Changes:**
- Map `k_decimal128` to `DOUBLE` in schema inference (previously fell through to VARCHAR)
- Add explicit cases for all BSON types in `InferTypeFromBSONElement` to improve code clarity
- Handle Decimal128 conversion in `FlattenDocument` for HUGEINT and DOUBLE target types
- Add test coverage for Decimal128 aggregate operations

## Problem

Previously, Decimal128 fields were inferred as VARCHAR because the schema inference switch statement had no explicit case for `k_decimal128`. This meant:
1. Users couldn't run `SUM()`, `AVG()`, or other numeric aggregates on Decimal128 columns
2. If aggregates were pushed down and MongoDB returned Decimal128, the result would silently be 0

## Solution

1. **Schema Inference**: Add `k_decimal128` case that maps to `LogicalType::DOUBLE`
2. **FlattenDocument**: Parse Decimal128 string values when target type is HUGEINT or DOUBLE
3. **Explicit BSON type handling**: Add cases for k_null, k_undefined, k_regex, k_code, k_codewscope, k_symbol, k_timestamp, k_dbpointer, k_minkey, k_maxkey

## Test Plan

- [x] Added `decimal_test` collection with Decimal128 values
- [x] Added tests for COUNT, SUM, AVG on Decimal128 fields