### PR TITLE
fix: filter pushdown misinterpreting string _id as ObjectId

### DIFF
--- a/benchmarks/create-tpch-mongo.sh
+++ b/benchmarks/create-tpch-mongo.sh
@@ -2,16 +2,24 @@
 # Script to generate TPC-H data and load it into MongoDB
 # Similar to create-postgres-tables.sh but adapted for MongoDB
 
-set -e
+set -eo pipefail
 
-DUCKDB_PATH=duckdb
+DUCKDB_PATH=""
 if test -f build/release/duckdb; then
   DUCKDB_PATH=./build/release/duckdb
 elif test -f build/reldebug/duckdb; then
   DUCKDB_PATH=./build/reldebug/duckdb
 elif test -f build/debug/duckdb; then
   DUCKDB_PATH=./build/debug/duckdb
+elif command -v duckdb &>/dev/null; then
+  DUCKDB_PATH=duckdb
+else
+  echo "Error: DuckDB binary not found."
+  echo "Build the project first: make release"
+  exit 1
 fi
+
+echo "Using DuckDB: $DUCKDB_PATH"
 
 MONGO_HOST=${MONGO_HOST:-localhost}
 MONGO_PORT=${MONGO_PORT:-27017}
@@ -25,29 +33,33 @@ echo "=== Generating TPC-H data (scale factor: $SCALE_FACTOR) ==="
 TEMP_DB="/tmp/tpch_mongo_tmp/tpch_data.duckdb"
 mkdir -p /tmp/tpch_mongo_tmp
 
-# Generate TPC-H data in DuckDB
-# First drop schema if it exists from previous run
-echo "
-DROP SCHEMA IF EXISTS tpch CASCADE;
-" | $DUCKDB_PATH $TEMP_DB 2>/dev/null || true
+# Run each step separately with -c for reliable error detection.
+# DuckDB may exit 0 on SQL errors when reading from stdin/file, but -c propagates errors.
+$DUCKDB_PATH $TEMP_DB -c "DROP SCHEMA IF EXISTS tpch CASCADE;" 2>/dev/null || true
 
-# Generate TPC-H data
-# The tpch extension should be available when DuckDB is built with extension support
-# Try to load it - if it fails, the error message will guide the user
-echo "
-LOAD tpch;
-CREATE SCHEMA tpch;
-CALL dbgen(sf=$SCALE_FACTOR, schema='tpch');
-" | $DUCKDB_PATH $TEMP_DB || {
-    echo ""
+$DUCKDB_PATH $TEMP_DB -c "LOAD tpch;" || {
     echo "Error: Failed to load tpch extension."
-    echo ""
-    echo "The tpch extension needs to be available. Options:"
-    echo "1. Rebuild DuckDB with tpch extension: make clean && make"
-    echo "2. Or install tpch extension manually (if available online)"
-    echo ""
+    echo "Rebuild DuckDB with tpch: make clean && make release"
     exit 1
 }
+
+$DUCKDB_PATH $TEMP_DB -c "CREATE SCHEMA IF NOT EXISTS tpch;" || {
+    echo "Error: Failed to create tpch schema."
+    exit 1
+}
+
+$DUCKDB_PATH $TEMP_DB -c "LOAD tpch; CALL dbgen(sf=$SCALE_FACTOR, schema='tpch');" || {
+    echo "Error: Failed to generate TPC-H data with dbgen."
+    exit 1
+}
+
+# Verify data was actually generated
+REGION_COUNT=$($DUCKDB_PATH $TEMP_DB -csv -noheader -c "SELECT count(*) FROM tpch.region;" 2>&1) || {
+    echo "Error: TPC-H schema exists but has no data."
+    echo "DuckDB output: $REGION_COUNT"
+    exit 1
+}
+echo "TPC-H data generated successfully ($REGION_COUNT regions)"
 
 echo ""
 echo "=== Loading TPC-H data into MongoDB ==="
@@ -75,15 +87,12 @@ for table in "${TPCH_TABLES[@]}"; do
     CSV_FILE="/tmp/tpch_mongo_tmp/${table}_export.csv"
     
     # Export table to CSV from the temporary database
-    # Note: tpch extension is already loaded in TEMP_DB
-    echo "
-    USE tpch;
-    COPY (SELECT * FROM $table) TO '$CSV_FILE' (HEADER, DELIMITER '|');
-    " | $DUCKDB_PATH $TEMP_DB
+    $DUCKDB_PATH $TEMP_DB -c "USE tpch; COPY (SELECT * FROM $table) TO '$CSV_FILE' (HEADER, DELIMITER '|');"
     
     if [ ! -f "$CSV_FILE" ]; then
-        echo "Warning: Failed to export $table to CSV, skipping"
-        continue
+        echo "Error: Failed to export $table to CSV"
+        echo "Check that DuckDB ($DUCKDB_PATH) has the tpch extension and the dbgen step succeeded."
+        exit 1
     fi
     
     # Load CSV into MongoDB using mongosh

--- a/src/include/mongo_filter_pushdown.hpp
+++ b/src/include/mongo_filter_pushdown.hpp
@@ -19,6 +19,7 @@
 #include <bsoncxx/document/value.hpp>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace duckdb {
@@ -62,6 +63,7 @@ inline void MongoSetFilter(TableFilterSet &tfs, idx_t col_idx, unique_ptr<TableF
 bsoncxx::document::value
 ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet> filters, const std::vector<std::string> &column_names,
                            const std::vector<LogicalType> &column_types,
-                           const std::unordered_map<std::string, std::string> &column_name_to_mongo_path);
+                           const std::unordered_map<std::string, std::string> &column_name_to_mongo_path,
+                           const std::unordered_set<std::string> &objectid_columns);
 
 } // namespace duckdb

--- a/src/include/mongo_filter_pushdown.hpp
+++ b/src/include/mongo_filter_pushdown.hpp
@@ -41,7 +41,7 @@ template <typename Fn>
 inline void MongoForEachFilter(TableFilterSet &tfs, Fn fn) {
 #ifdef DUCKDB_PRIVATE_TABLE_FILTERS
 	for (auto &entry : tfs) {
-		fn(entry.ColumnIndex(), entry.Filter());
+		fn(static_cast<idx_t>(entry.GetIndex()), entry.Filter());
 	}
 #else
 	for (auto &entry : tfs.filters) {
@@ -52,7 +52,7 @@ inline void MongoForEachFilter(TableFilterSet &tfs, Fn fn) {
 
 inline void MongoSetFilter(TableFilterSet &tfs, idx_t col_idx, unique_ptr<TableFilter> filter) {
 #ifdef DUCKDB_PRIVATE_TABLE_FILTERS
-	tfs.SetFilterByColumnIndex(col_idx, std::move(filter));
+	tfs.SetFilterByColumnIndex(ProjectionIndex(col_idx), std::move(filter));
 #else
 	tfs.filters[col_idx] = std::move(filter);
 #endif

--- a/src/include/mongo_table_function.hpp
+++ b/src/include/mongo_table_function.hpp
@@ -8,6 +8,7 @@
 #include <bsoncxx/json.hpp>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace duckdb {
@@ -48,6 +49,10 @@ struct MongoScanData : public TableFunctionData {
 	// Mapping from flattened column name to original MongoDB path (for filter pushdown)
 	// e.g., "address_city" -> "address.city", "l_returnflag" -> "l_returnflag"
 	unordered_map<string, string> column_name_to_mongo_path;
+
+	// Columns whose BSON type is k_oid (actual ObjectId), keyed by MongoDB path.
+	// Used by filter pushdown to decide whether to send bsoncxx::oid vs plain string.
+	std::unordered_set<std::string> objectid_columns;
 
 	// Complex filter pushdown: MongoDB $expr queries for complex expressions
 	bsoncxx::document::value complex_filter_expr;
@@ -123,6 +128,9 @@ bool ValidateDocumentSchema(const bsoncxx::document::view &doc, const std::vecto
                             const std::vector<LogicalType> &column_types,
                             const std::unordered_map<std::string, std::string> &column_name_to_mongo_path,
                             SchemaMode schema_mode);
+
+// Probe one document to discover which fields have BSON ObjectId type
+void DetectObjectIdColumns(mongocxx::collection &collection, std::unordered_set<std::string> &objectid_columns);
 
 // Projection pushdown function
 bsoncxx::document::value BuildMongoProjection(const vector<column_t> &column_ids,

--- a/src/mongo_filter_pushdown.cpp
+++ b/src/mongo_filter_pushdown.cpp
@@ -19,7 +19,6 @@
 namespace duckdb {
 namespace {
 
-// Check if a string is a valid MongoDB ObjectID hex string (24 hex characters)
 static bool IsValidObjectIdHex(const string &str) {
 	if (str.size() != 24) {
 		return false;
@@ -32,26 +31,14 @@ static bool IsValidObjectIdHex(const string &str) {
 	return true;
 }
 
-// Check if a column name represents an ObjectID field
-// Returns true for "_id" and fields ending with "_id" (common foreign key pattern)
-static bool IsObjectIdColumn(const string &column_name) {
-	if (column_name == "_id") {
-		return true;
-	}
-	// Check for nested _id (e.g., "customer._id")
-	if (column_name.size() > 4 && column_name.substr(column_name.size() - 4) == "._id") {
-		return true;
-	}
-	// Check for foreign key pattern (e.g., "customer_id", "user_id")
-	if (column_name.size() > 3 && column_name.substr(column_name.size() - 3) == "_id") {
-		return true;
-	}
-	return false;
+static bool IsActualObjectIdColumn(const string &column_name, const unordered_set<string> &objectid_columns) {
+	return objectid_columns.count(column_name) > 0;
 }
 
 // Helper function to append a DuckDB Value to a MongoDB basic array builder
 static void AppendValueToArray(bsoncxx::builder::basic::array &array_builder, const Value &value,
-                               const LogicalType &type, const string &column_name = "") {
+                               const LogicalType &type, const string &column_name,
+                               const unordered_set<string> &objectid_columns) {
 	if (value.IsNull()) {
 		array_builder.append(bsoncxx::types::b_null {});
 		return;
@@ -60,8 +47,7 @@ static void AppendValueToArray(bsoncxx::builder::basic::array &array_builder, co
 	switch (type.id()) {
 	case LogicalTypeId::VARCHAR: {
 		auto str_val = value.GetValue<string>();
-		// Convert to ObjectID if this is an ObjectID column and the value is a valid hex string
-		if (IsObjectIdColumn(column_name) && IsValidObjectIdHex(str_val)) {
+		if (IsActualObjectIdColumn(column_name, objectid_columns) && IsValidObjectIdHex(str_val)) {
 			array_builder.append(bsoncxx::oid(str_val));
 		} else {
 			array_builder.append(str_val);
@@ -110,10 +96,9 @@ static void AppendValueToArray(bsoncxx::builder::basic::array &array_builder, co
 	}
 }
 
-// Helper function to append a DuckDB Value to a MongoDB basic document builder
-// column_name is the original column name (used to detect ObjectID fields)
 static void AppendValueToDocument(bsoncxx::builder::basic::document &doc_builder, const string &key, const Value &value,
-                                  const LogicalType &type, const string &column_name = "") {
+                                  const LogicalType &type, const string &column_name,
+                                  const unordered_set<string> &objectid_columns) {
 	if (value.IsNull()) {
 		doc_builder.append(bsoncxx::builder::basic::kvp(key, bsoncxx::types::b_null {}));
 		return;
@@ -125,8 +110,7 @@ static void AppendValueToDocument(bsoncxx::builder::basic::document &doc_builder
 	switch (type.id()) {
 	case LogicalTypeId::VARCHAR: {
 		auto str_val = value.GetValue<string>();
-		// Convert to ObjectID if this is an ObjectID column and the value is a valid hex string
-		if (IsObjectIdColumn(col_for_oid_check) && IsValidObjectIdHex(str_val)) {
+		if (IsActualObjectIdColumn(col_for_oid_check, objectid_columns) && IsValidObjectIdHex(str_val)) {
 			doc_builder.append(bsoncxx::builder::basic::kvp(key, bsoncxx::oid(str_val)));
 		} else {
 			doc_builder.append(bsoncxx::builder::basic::kvp(key, str_val));
@@ -177,9 +161,9 @@ static void AppendValueToDocument(bsoncxx::builder::basic::document &doc_builder
 	}
 }
 
-// Convert a single filter to MongoDB query document
 static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &filter, const string &column_name,
-                                                           const LogicalType &column_type) {
+                                                           const LogicalType &column_type,
+                                                           const unordered_set<string> &objectid_columns) {
 	bsoncxx::builder::basic::document doc;
 
 	switch (filter.filter_type) {
@@ -189,7 +173,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 
 		switch (constant_filter.comparison_type) {
 		case ExpressionType::COMPARE_EQUAL:
-			AppendValueToDocument(doc, column_name, constant_filter.constant, column_type, column_name);
+			AppendValueToDocument(doc, column_name, constant_filter.constant, column_type, column_name, objectid_columns);
 			break;
 		case ExpressionType::COMPARE_NOTEQUAL:
 			mongo_op = "$ne";
@@ -213,7 +197,8 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 
 		if (!mongo_op.empty()) {
 			bsoncxx::builder::basic::document op_doc;
-			AppendValueToDocument(op_doc, mongo_op, constant_filter.constant, column_type, column_name);
+			AppendValueToDocument(op_doc, mongo_op, constant_filter.constant, column_type, column_name,
+			                     objectid_columns);
 			doc.append(bsoncxx::builder::basic::kvp(column_name, op_doc.extract()));
 		}
 		break;
@@ -225,7 +210,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		}
 		bsoncxx::builder::basic::array in_array;
 		for (const auto &val : in_filter.values) {
-			AppendValueToArray(in_array, val, column_type, column_name);
+			AppendValueToArray(in_array, val, column_type, column_name, objectid_columns);
 		}
 		bsoncxx::builder::basic::document in_doc;
 		in_doc.append(bsoncxx::builder::basic::kvp("$in", in_array.extract()));
@@ -247,7 +232,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		const auto &conj_filter = static_cast<const ConjunctionFilter &>(filter);
 		bsoncxx::builder::basic::document merged_doc;
 		for (const auto &child_filter : conj_filter.child_filters) {
-			auto child_doc = ConvertSingleFilterToMongo(*child_filter, column_name, column_type);
+			auto child_doc = ConvertSingleFilterToMongo(*child_filter, column_name, column_type, objectid_columns);
 			// Extract conditions from child_doc and merge
 			for (auto it = child_doc.view().begin(); it != child_doc.view().end(); ++it) {
 				if (it->key() == column_name && it->type() == bsoncxx::type::k_document) {
@@ -275,13 +260,13 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 				const auto &cf = child_filter->Cast<ConstantFilter>();
 				if (cf.comparison_type == ExpressionType::COMPARE_EQUAL) {
 					bsoncxx::builder::basic::document or_doc;
-					AppendValueToDocument(or_doc, column_name, cf.constant, column_type, column_name);
+					AppendValueToDocument(or_doc, column_name, cf.constant, column_type, column_name, objectid_columns);
 					or_array.append(or_doc.extract());
 					continue;
 				}
 			}
 
-			auto child_doc = ConvertSingleFilterToMongo(*child_filter, column_name, column_type);
+			auto child_doc = ConvertSingleFilterToMongo(*child_filter, column_name, column_type, objectid_columns);
 			if (!child_doc.view().empty()) {
 				or_array.append(child_doc.view());
 			}
@@ -297,7 +282,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		const auto &struct_filter = filter.Cast<StructFilter>();
 		if (struct_filter.child_filter) {
 			string nested_path = column_name + "." + struct_filter.child_name;
-			return ConvertSingleFilterToMongo(*struct_filter.child_filter, nested_path, column_type);
+			return ConvertSingleFilterToMongo(*struct_filter.child_filter, nested_path, column_type, objectid_columns);
 		}
 		break;
 	}
@@ -305,7 +290,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		// OptionalFilter wraps another filter (often IN filters from semi-join pushdown)
 		const auto &opt_filter = filter.Cast<OptionalFilter>();
 		if (opt_filter.child_filter) {
-			return ConvertSingleFilterToMongo(*opt_filter.child_filter, column_name, column_type);
+			return ConvertSingleFilterToMongo(*opt_filter.child_filter, column_name, column_type, objectid_columns);
 		}
 		break;
 	}
@@ -316,7 +301,8 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 			break;
 		}
 		if (dyn_filter.filter_data->filter) {
-			return ConvertSingleFilterToMongo(*dyn_filter.filter_data->filter, column_name, column_type);
+			return ConvertSingleFilterToMongo(*dyn_filter.filter_data->filter, column_name, column_type,
+			                                 objectid_columns);
 		}
 		break;
 	}
@@ -332,7 +318,8 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 bsoncxx::document::value
 ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet> filters, const std::vector<string> &column_names,
                            const std::vector<LogicalType> &column_types,
-                           const std::unordered_map<string, string> &column_name_to_mongo_path) {
+                           const std::unordered_map<string, string> &column_name_to_mongo_path,
+                           const std::unordered_set<string> &objectid_columns) {
 	if (!filters || !MongoHasFilters(*filters)) {
 		return bsoncxx::builder::basic::document {}.extract();
 	}
@@ -357,7 +344,7 @@ ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet> filters, const std::vect
 			mongo_column_name = path_it->second;
 		}
 
-		auto filter_doc = ConvertSingleFilterToMongo(filter_ref, mongo_column_name, column_type);
+		auto filter_doc = ConvertSingleFilterToMongo(filter_ref, mongo_column_name, column_type, objectid_columns);
 
 		// Skip empty filters
 		if (filter_doc.view().empty()) {

--- a/src/mongo_filter_pushdown.cpp
+++ b/src/mongo_filter_pushdown.cpp
@@ -173,7 +173,8 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 
 		switch (constant_filter.comparison_type) {
 		case ExpressionType::COMPARE_EQUAL:
-			AppendValueToDocument(doc, column_name, constant_filter.constant, column_type, column_name, objectid_columns);
+			AppendValueToDocument(doc, column_name, constant_filter.constant, column_type, column_name,
+			                      objectid_columns);
 			break;
 		case ExpressionType::COMPARE_NOTEQUAL:
 			mongo_op = "$ne";
@@ -198,7 +199,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		if (!mongo_op.empty()) {
 			bsoncxx::builder::basic::document op_doc;
 			AppendValueToDocument(op_doc, mongo_op, constant_filter.constant, column_type, column_name,
-			                     objectid_columns);
+			                      objectid_columns);
 			doc.append(bsoncxx::builder::basic::kvp(column_name, op_doc.extract()));
 		}
 		break;
@@ -302,7 +303,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		}
 		if (dyn_filter.filter_data->filter) {
 			return ConvertSingleFilterToMongo(*dyn_filter.filter_data->filter, column_name, column_type,
-			                                 objectid_columns);
+			                                  objectid_columns);
 		}
 		break;
 	}
@@ -315,11 +316,11 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 
 } // namespace
 
-bsoncxx::document::value
-ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet> filters, const std::vector<string> &column_names,
-                           const std::vector<LogicalType> &column_types,
-                           const std::unordered_map<string, string> &column_name_to_mongo_path,
-                           const std::unordered_set<string> &objectid_columns) {
+bsoncxx::document::value ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet> filters,
+                                                    const std::vector<string> &column_names,
+                                                    const std::vector<LogicalType> &column_types,
+                                                    const std::unordered_map<string, string> &column_name_to_mongo_path,
+                                                    const std::unordered_set<string> &objectid_columns) {
 	if (!filters || !MongoHasFilters(*filters)) {
 		return bsoncxx::builder::basic::document {}.extract();
 	}

--- a/src/mongo_optimizer.cpp
+++ b/src/mongo_optimizer.cpp
@@ -128,9 +128,9 @@ static bsoncxx::document::value BuildMatchFromExistingFilters(const LogicalGet &
 		// ConvertFiltersToMongoQuery expects a mutable TableFilterSet (optional_ptr<TableFilterSet>),
 		// but LogicalGet::table_filters is const here. Copy the filter set for translation.
 		auto filters_copy = get.table_filters.Copy();
-		auto simple = ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet>(filters_copy.get()), data.column_names,
-		                                         data.column_types, data.column_name_to_mongo_path,
-		                                         data.objectid_columns);
+		auto simple =
+		    ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet>(filters_copy.get()), data.column_names,
+		                               data.column_types, data.column_name_to_mongo_path, data.objectid_columns);
 		if (!DocIsEmpty(simple.view())) {
 			conjuncts.push_back(std::move(simple));
 		}

--- a/src/mongo_optimizer.cpp
+++ b/src/mongo_optimizer.cpp
@@ -129,7 +129,8 @@ static bsoncxx::document::value BuildMatchFromExistingFilters(const LogicalGet &
 		// but LogicalGet::table_filters is const here. Copy the filter set for translation.
 		auto filters_copy = get.table_filters.Copy();
 		auto simple = ConvertFiltersToMongoQuery(optional_ptr<TableFilterSet>(filters_copy.get()), data.column_names,
-		                                         data.column_types, data.column_name_to_mongo_path);
+		                                         data.column_types, data.column_name_to_mongo_path,
+		                                         data.objectid_columns);
 		if (!DocIsEmpty(simple.view())) {
 			conjuncts.push_back(std::move(simple));
 		}

--- a/src/mongo_optimizer.cpp
+++ b/src/mongo_optimizer.cpp
@@ -53,7 +53,8 @@ static void ApplyBindingRulesToExpression(unique_ptr<Expression> &expr, const ve
 		    for (const auto &rule : rules) {
 			    if (colref.binding.table_index == rule.from_table_index) {
 				    colref.binding.table_index = rule.to_table_index;
-				    colref.binding.column_index += rule.column_offset;
+				    colref.binding.column_index =
+				        decltype(colref.binding.column_index)(idx_t(colref.binding.column_index) + rule.column_offset);
 			    }
 		    }
 	    });

--- a/src/mongo_schema_inference.cpp
+++ b/src/mongo_schema_inference.cpp
@@ -510,6 +510,33 @@ void InferSchemaFromDocuments(mongocxx::collection &collection, int64_t sample_s
 	}
 }
 
+namespace {
+
+void CollectObjectIdFieldsRecursive(const bsoncxx::document::view &doc, const std::string &mongo_prefix,
+                                    std::unordered_set<std::string> &objectid_columns) {
+	for (const auto &elem : doc) {
+		std::string field_name(elem.key().data(), elem.key().length());
+		std::string mongo_path = mongo_prefix.empty() ? field_name : mongo_prefix + "." + field_name;
+
+		if (elem.type() == bsoncxx::type::k_oid) {
+			objectid_columns.insert(mongo_path);
+		} else if (elem.type() == bsoncxx::type::k_document) {
+			CollectObjectIdFieldsRecursive(elem.get_document().value, mongo_path, objectid_columns);
+		}
+	}
+}
+
+} // namespace
+
+void DetectObjectIdColumns(mongocxx::collection &collection, std::unordered_set<std::string> &objectid_columns) {
+	mongocxx::options::find opts;
+	opts.limit(1);
+	auto cursor = collection.find({}, opts);
+	for (const auto &doc : cursor) {
+		CollectObjectIdFieldsRecursive(doc, "", objectid_columns);
+	}
+}
+
 // Validation-only function that checks schema compatibility without writing to output
 // Used for COUNT(*) queries where we need to validate but not materialize data
 bool ValidateDocumentSchema(const bsoncxx::document::view &doc, const std::vector<string> &column_names,

--- a/src/mongo_table_function.cpp
+++ b/src/mongo_table_function.cpp
@@ -141,6 +141,10 @@ unique_ptr<FunctionData> MongoScanBind(ClientContext &context, TableFunctionBind
 		                         result->column_name_to_mongo_path);
 	}
 
+	// Probe one document to discover which fields are actual BSON ObjectIds.
+	// This avoids the heuristic of guessing by column name during filter pushdown.
+	DetectObjectIdColumns(collection, result->objectid_columns);
+
 	// Set return types and names
 	return_types = result->column_types;
 	names = result->column_names;
@@ -368,7 +372,7 @@ unique_ptr<LocalTableFunctionState> MongoScanInitLocal(ExecutionContext &context
 		if (MongoHasFilters(*remapped_filters)) {
 			// Convert DuckDB filters to MongoDB query using remapped indices
 			auto mongo_filter = ConvertFiltersToMongoQuery(remapped_filters.get(), data.column_names, data.column_types,
-			                                               data.column_name_to_mongo_path);
+			                                               data.column_name_to_mongo_path, data.objectid_columns);
 
 			// Check if filters were successfully pushed down (non-empty MongoDB query)
 			// If filters are pushed down to MongoDB, MongoDB filters server-side and we don't need filter columns

--- a/test/create-mongo-tables.sh
+++ b/test/create-mongo-tables.sh
@@ -334,6 +334,29 @@ db.object_container_test.insertMany([
   }
 ]);
 
+// Collection with string _id values that happen to be 24 hex characters (NOT ObjectIds).
+// Reproduces issue #27: filter pushdown must not convert these to ObjectId.
+db.string_id_test.insertMany([
+  {
+    _id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+    name: 'Doc1',
+    value: 100,
+    ref_id: 'bbbbbbbbbbbbbbbbbbbbbbbb'
+  },
+  {
+    _id: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+    name: 'Doc2',
+    value: 200,
+    ref_id: 'aaaaaaaaaaaaaaaaaaaaaaaa'
+  },
+  {
+    _id: 'cccccccccccccccccccccccc',
+    name: 'Doc3',
+    value: 300,
+    ref_id: 'aaaaaaaaaaaaaaaaaaaaaaaa'
+  }
+]);
+
 // Create collections with __schema documents for testing schema functionality
 // These simulate Atlas SQL collections with predefined schemas
 
@@ -477,7 +500,7 @@ print('Collections: ' + db.getCollectionNames().join(', '));
 
 echo ""
 echo "Test MongoDB database '$MONGO_DB' created successfully!"
-echo "Collections: users, products, orders, decimal_test, empty_collection, type_conflicts, deeply_nested, nested_scalars_test, object_container_test, schema_test_simple, schema_test_nested, schema_test_paths, schema_test_with_id, schema_test_types"
+echo "Collections: users, products, orders, decimal_test, empty_collection, type_conflicts, deeply_nested, nested_scalars_test, object_container_test, string_id_test, schema_test_simple, schema_test_nested, schema_test_paths, schema_test_with_id, schema_test_types"
 echo ""
 
 # Export environment variables for tests

--- a/test/sql/attach/catalog_operations.test
+++ b/test/sql/attach/catalog_operations.test
@@ -43,6 +43,7 @@ schema_test_paths
 schema_test_simple
 schema_test_types
 schema_test_with_id
+string_id_test
 type_conflicts
 users
 
@@ -70,6 +71,7 @@ mongo_db	duckdb_mongo_test	schema_test_paths
 mongo_db	duckdb_mongo_test	schema_test_simple
 mongo_db	duckdb_mongo_test	schema_test_types
 mongo_db	duckdb_mongo_test	schema_test_with_id
+mongo_db	duckdb_mongo_test	string_id_test
 mongo_db	duckdb_mongo_test	type_conflicts
 mongo_db	duckdb_mongo_test	users
 
@@ -123,7 +125,7 @@ query I
 SELECT COUNT(*) FROM duckdb_views() 
 WHERE database_name = 'mongo_db' AND schema_name = 'duckdb_mongo_test';
 ----
-15
+16
 
 query I
 SELECT column_name FROM duckdb_columns() 

--- a/test/sql/cache/clear_cache.test
+++ b/test/sql/cache/clear_cache.test
@@ -45,7 +45,7 @@ SELECT COUNT(*) FROM information_schema.tables
 WHERE table_catalog = 'test_mongo' 
   AND table_schema = 'duckdb_mongo_test';
 ----
-15
+16
 
 # Query collections again - should use cached data
 query I
@@ -53,7 +53,7 @@ SELECT COUNT(*) FROM information_schema.tables
 WHERE table_catalog = 'test_mongo' 
   AND table_schema = 'duckdb_mongo_test';
 ----
-15
+16
 
 # Get list of collections (this uses cached collection names)
 query T
@@ -75,6 +75,7 @@ schema_test_paths
 schema_test_simple
 schema_test_types
 schema_test_with_id
+string_id_test
 type_conflicts
 users
 
@@ -92,7 +93,7 @@ SELECT COUNT(*) FROM information_schema.tables
 WHERE table_catalog = 'test_mongo' 
   AND table_schema = 'duckdb_mongo_test';
 ----
-15
+16
 
 # Verify we get the same collections (proving fresh data was fetched, not stale cache)
 query T
@@ -114,6 +115,7 @@ schema_test_paths
 schema_test_simple
 schema_test_types
 schema_test_with_id
+string_id_test
 type_conflicts
 users
 

--- a/test/sql/query/objectid_filter.test
+++ b/test/sql/query/objectid_filter.test
@@ -1,5 +1,5 @@
 # name: test/sql/query/objectid_filter.test
-# description: Test filtering on ObjectID fields (_id and foreign key references)
+# description: Test filtering on ObjectID fields and plain-string _id fields (issue #23, #27)
 # group: [query]
 
 require mongo
@@ -65,6 +65,40 @@ SELECT name, email FROM mongo_test.users WHERE _id > '507f1f77bcf86cd799439011' 
 ----
 Bob	bob@example.com
 Charlie	charlie@example.com
+
+# The string_id_test collection has documents where _id is a 24-hex-char string (NOT ObjectId).
+# Filter pushdown must send string comparisons, not ObjectId comparisons.
+
+query II
+SELECT name, value FROM mongo_test.string_id_test WHERE _id = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+----
+Doc1	100
+
+query II
+SELECT name, value FROM mongo_test.string_id_test WHERE _id = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+----
+Doc2	200
+
+# IN filter on string _id
+query II
+SELECT name, value FROM mongo_test.string_id_test WHERE _id IN ('aaaaaaaaaaaaaaaaaaaaaaaa', 'cccccccccccccccccccccccc') ORDER BY name;
+----
+Doc1	100
+Doc3	300
+
+# Range filter on string _id
+query II
+SELECT name, value FROM mongo_test.string_id_test WHERE _id > 'aaaaaaaaaaaaaaaaaaaaaaaa' AND _id <= 'cccccccccccccccccccccccc' ORDER BY _id;
+----
+Doc2	200
+Doc3	300
+
+# Verify ref_id (a non-_id column with 24-hex values) also works as string
+query II
+SELECT name, value FROM mongo_test.string_id_test WHERE ref_id = 'aaaaaaaaaaaaaaaaaaaaaaaa' ORDER BY name;
+----
+Doc2	200
+Doc3	300
 
 statement ok
 DETACH mongo_test;


### PR DESCRIPTION
- Fixes #27: filter pushdown incorrectly converted 24-character hex string _id values to BSON ObjectId, returning no results when the actual _id type in MongoDB was a plain string. The previous filter pushdown logic used IsObjectIdColumn() which guessed ObjectId columns by name pattern (e.g., _id, *_id). This broke for collections where _id is stored as a plain string that happens to be 24 hex characters -- the filter would send ObjectId("aaa...") to MongoDB instead of "aaa...", matching nothing. The fix introduces DetectObjectIdColumns() which probes one document from the collection to discover which fields actually have BSON ObjectId type. This set is stored in MongoScanData::objectid_columns and threaded through to ConvertFiltersToMongoQuery, replacing the heuristic with a definitive check.

- Replaced the name-based heuristic (any column named _id or ending in _id) with actual BSON type detection by sampling one document during bind. Only columns whose BSON type is k_oid are now treated as ObjectIds during filter pushdown.
- Fixed TPC-H data generation script reliability (DuckDB silently exits 0 on SQL errors when reading from stdin/pipe).