### PR TITLE
fix: nested document fields not queryable as whole columns

### DIFF
--- a/src/mongo_schema_inference.cpp
+++ b/src/mongo_schema_inference.cpp
@@ -219,11 +219,12 @@ void CollectFieldPaths(const bsoncxx::document::view &doc, const std::string &pr
 
 		switch (element.type()) {
 		case bsoncxx::type::k_document: {
-			// Recursively process nested document
+			// Recursively process nested document to create flattened child columns.
 			auto nested_doc = element.get_document().value;
 			CollectFieldPaths(nested_doc, full_path, depth + 1, field_types, flattened_to_mongo_path, mongo_path);
-			// Don't store the document itself as JSON when we have nested fields
-			// This prevents VARCHAR from overriding nested STRUCT types
+			// Also expose the parent document itself as a VARCHAR column containing JSON.
+			// This allows users to query the whole sub-document directly.
+			field_types[full_path].push_back(LogicalType::VARCHAR);
 			break;
 		}
 		case bsoncxx::type::k_array: {

--- a/test/sql/attach/catalog_operations.test
+++ b/test/sql/attach/catalog_operations.test
@@ -83,6 +83,7 @@ SELECT column_name, column_type FROM (DESCRIBE mongo_db.duckdb_mongo_test.users)
 ----
 _id	VARCHAR
 active	BOOLEAN
+address	VARCHAR
 address_city	VARCHAR
 address_country	VARCHAR
 address_street	VARCHAR
@@ -99,6 +100,7 @@ SELECT name, type FROM pragma_table_info('mongo_db.duckdb_mongo_test.users') ORD
 ----
 _id	VARCHAR
 active	BOOLEAN
+address	VARCHAR
 address_city	VARCHAR
 address_country	VARCHAR
 address_street	VARCHAR

--- a/test/sql/schema/schema.test
+++ b/test/sql/schema/schema.test
@@ -146,6 +146,43 @@ SELECT COUNT(*) FROM mongo_test.empty_collection WHERE _id IS NOT NULL;
 ----
 0
 
+# ============================================================================
+# Parent document fields queryable as JSON
+# ============================================================================
+
+# Test that parent document fields are exposed as VARCHAR columns containing JSON.
+# Previously, nested document fields like "address" were flattened into
+# address_street, address_city, etc., but the parent "address" field itself
+# was not queryable. Users should be able to query both the parent and children.
+
+# Parent document field "address" should be queryable (not NULL) and contain expected data.
+query IT
+SELECT name, address IS NOT NULL FROM mongo_test.users WHERE name = 'Alice';
+----
+Alice	true
+
+query I
+SELECT address LIKE '%New York%' AND address LIKE '%123 Main St%' FROM mongo_test.users WHERE name = 'Alice';
+----
+true
+
+# Parent document field "specs" should be queryable.
+query IT
+SELECT name, specs IS NOT NULL FROM mongo_test.products WHERE name = 'Laptop';
+----
+Laptop	true
+
+query I
+SELECT specs LIKE '%Intel i7%' AND specs LIKE '%16GB%' FROM mongo_test.products WHERE name = 'Laptop';
+----
+true
+
+# Flattened children should still work alongside the parent field.
+query ITTT
+SELECT name, address IS NOT NULL, address_city, address_street FROM mongo_test.users WHERE name = 'Bob';
+----
+Bob	true	Los Angeles	456 Oak Ave
+
 statement ok
 DETACH mongo_test;
 


### PR DESCRIPTION
Closes https://github.com/stephaniewang526/duckdb-mongo/issues/30

Nested MongoDB documents (e.g., address, specs) were only accessible through their flattened child columns (e.g., address_city, address_street), but the parent document itself was not queryable.

In CollectFieldPaths, when a k_document BSON type was encountered, the code recursed into the children to create flattened columns but explicitly skipped adding the parent field to the schema. This meant there was no column for the parent document itself.

The fix added the parent document field as a VARCHAR column containing the JSON representation of the sub-document, alongside the existing flattened child columns. The read path in FlattenDocument already handled serializing k_document elements to JSON for VARCHAR columns, so only the schema inference needed updating.