### PR TITLE
fix: use random sampling for schema inference to detect sparse fields

### DIFF
--- a/src/include/mongo_compat.hpp
+++ b/src/include/mongo_compat.hpp
@@ -63,6 +63,13 @@ inline void MongoVectorReferenceSingleValue(Vector &vec, const Value &val) {
 #endif
 }
 
+// Set a flat vector's tracked size (DuckDB main tracks per-vector sizes for DataChunk::Verify).
+inline void MongoSetVectorSize(Vector &vec, idx_t size) {
+#ifdef DUCKDB_MAIN_VECTOR_API
+	FlatVector::SetSize(vec, size);
+#endif
+}
+
 // DuckDB main made Expression::return_type and BaseExpression::type protected.
 // Provide accessor helpers that compile on both v1.5.x (public fields) and main (getters).
 #ifdef DUCKDB_MAIN_VECTOR_API

--- a/src/include/mongo_compat.hpp
+++ b/src/include/mongo_compat.hpp
@@ -63,4 +63,14 @@ inline void MongoVectorReferenceSingleValue(Vector &vec, const Value &val) {
 #endif
 }
 
+// DuckDB main made Expression::return_type and BaseExpression::type protected.
+// Provide accessor helpers that compile on both v1.5.x (public fields) and main (getters).
+#ifdef DUCKDB_MAIN_VECTOR_API
+#define MONGO_EXPR_RETURN_TYPE(expr) ((expr).GetReturnType())
+#define MONGO_EXPR_TYPE(expr)        ((expr).GetExpressionType())
+#else
+#define MONGO_EXPR_RETURN_TYPE(expr) ((expr).return_type)
+#define MONGO_EXPR_TYPE(expr)        ((expr).GetExpressionType())
+#endif
+
 } // namespace duckdb

--- a/src/mongo_expr_pushdown.cpp
+++ b/src/mongo_expr_pushdown.cpp
@@ -1,5 +1,6 @@
 #include "mongo_expr_pushdown.hpp"
 
+#include "mongo_compat.hpp"
 #include "mongo_filter_pushdown.hpp"
 #include "mongo_table_function.hpp"
 
@@ -147,7 +148,7 @@ static bool ValidateFunctionSignature(const BoundFunctionExpression &func_expr, 
 	// Check required argument types if specified
 	if (!mapping.required_arg_types.empty() && mapping.required_arg_types.size() == mapping.arg_count) {
 		for (idx_t i = 0; i < mapping.arg_count; i++) {
-			if (func_expr.children[i]->return_type.id() != mapping.required_arg_types[i]) {
+			if (MONGO_EXPR_RETURN_TYPE(*func_expr.children[i]).id() != mapping.required_arg_types[i]) {
 				return false;
 			}
 		}
@@ -158,7 +159,7 @@ static bool ValidateFunctionSignature(const BoundFunctionExpression &func_expr, 
 		if (func_expr.children.size() != 3) {
 			return false;
 		}
-		auto first_type = func_expr.children[0]->return_type.id();
+		auto first_type = MONGO_EXPR_RETURN_TYPE(*func_expr.children[0]).id();
 		if (first_type != LogicalTypeId::VARCHAR) {
 			return false;
 		}
@@ -347,7 +348,7 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 		}
 
 		// Handle complex comparisons: column-to-column, function calls, etc.
-		ExpressionType comp_type = comp_expr.type;
+		ExpressionType comp_type = MONGO_EXPR_TYPE(comp_expr);
 		string mongo_op;
 		switch (comp_type) {
 		case ExpressionType::COMPARE_GREATERTHAN:
@@ -396,10 +397,10 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 			// Cast constant to match left expression type if needed
 			// This handles cases like YEAR() returning BIGINT but constant being INTEGER
 			Value const_val = right_const.value;
-			if (left_expr->return_type != const_val.type()) {
+			if (MONGO_EXPR_RETURN_TYPE(*left_expr) != const_val.type()) {
 				Value casted_val;
 				string error_message;
-				if (const_val.DefaultTryCastAs(left_expr->return_type, casted_val, &error_message, true)) {
+				if (const_val.DefaultTryCastAs(MONGO_EXPR_RETURN_TYPE(*left_expr), casted_val, &error_message, true)) {
 					BoundConstantExpression casted_const(casted_val);
 					AppendConstantToBSONArray(casted_const, args_array);
 				} else {

--- a/src/mongo_optimizer.cpp
+++ b/src/mongo_optimizer.cpp
@@ -505,7 +505,7 @@ static bool RewriteMongoAggregate(unique_ptr<LogicalOperator> &node, vector<Bind
 			return false;
 		}
 		group_fields.emplace_back(col_name, it->second);
-		group_types.push_back(gexpr->return_type);
+		group_types.push_back(MONGO_EXPR_RETURN_TYPE(*gexpr));
 	}
 
 	// Aggregate expressions must be supported and direct
@@ -583,7 +583,7 @@ static bool RewriteMongoAggregate(unique_ptr<LogicalOperator> &node, vector<Bind
 				spec.append(bsoncxx::builder::basic::kvp(StringUtil::Format("$%s", kind),
 				                                         StringUtil::Format("$%s", path_it->second)));
 				// Preserve DuckDB aggregate return type
-				out_types.push_back(b.return_type);
+				out_types.push_back(MONGO_EXPR_RETURN_TYPE(b));
 			}
 
 			agg_specs.emplace_back(out_field, spec.extract());

--- a/src/mongo_schema_inference.cpp
+++ b/src/mongo_schema_inference.cpp
@@ -105,6 +105,32 @@ LogicalType ResolveTypeConflict(const std::vector<LogicalType> &types) {
 			}
 		}
 		if (max_depth > 0) {
+			// For LIST(STRUCT) types, merge struct fields from all variants so that
+			// optional fields present in only some documents are not lost.
+			auto inner = ListType::GetChildType(deepest_list_type);
+			if (inner.id() == LogicalTypeId::STRUCT) {
+				std::map<std::string, LogicalType> merged;
+				for (const auto &type : types) {
+					if (type.id() != LogicalTypeId::LIST) {
+						continue;
+					}
+					auto child = ListType::GetChildType(type);
+					if (child.id() != LogicalTypeId::STRUCT) {
+						continue;
+					}
+					for (idx_t i = 0; i < StructType::GetChildCount(child); i++) {
+						auto &name = StructType::GetChildName(child, i);
+						if (merged.find(name) == merged.end()) {
+							merged[name] = StructType::GetChildType(child, i);
+						}
+					}
+				}
+				child_list_t<LogicalType> children;
+				for (auto &pair : merged) {
+					children.push_back({pair.first, pair.second});
+				}
+				return LogicalType::LIST(LogicalType::STRUCT(children));
+			}
 			return deepest_list_type;
 		}
 		for (const auto &type : types) {

--- a/src/mongo_schema_inference.cpp
+++ b/src/mongo_schema_inference.cpp
@@ -15,6 +15,8 @@
 #include <bsoncxx/json.hpp>
 #include <mongocxx/collection.hpp>
 
+#include <mongocxx/pipeline.hpp>
+
 #include <algorithm>
 #include <cctype>
 #include <map>
@@ -466,18 +468,36 @@ void InferSchemaFromDocuments(mongocxx::collection &collection, int64_t sample_s
                               std::unordered_map<string, string> &column_name_to_mongo_path) {
 	std::unordered_map<std::string, std::vector<LogicalType>> field_types;
 
-	// Sample documents
-	mongocxx::options::find opts;
-	opts.limit(sample_size);
-
-	auto cursor = collection.find({}, opts);
-
+	// Use $sample aggregation for random sampling to better capture heterogeneous schemas.
+	// Collections with optional fields (e.g., completion timestamps only on finished records)
+	// need random sampling to discover all fields, since find().limit() only returns the
+	// first N documents in natural order.
 	int64_t count = 0;
-	for (const auto &doc : cursor) {
-		CollectFieldPaths(doc, "", 0, field_types, column_name_to_mongo_path, "");
-		count++;
-		if (count >= sample_size) {
-			break;
+	try {
+		mongocxx::pipeline pipe;
+		pipe.sample(static_cast<int32_t>(std::min(sample_size, static_cast<int64_t>(INT32_MAX))));
+		auto cursor = collection.aggregate(pipe);
+		for (const auto &doc : cursor) {
+			CollectFieldPaths(doc, "", 0, field_types, column_name_to_mongo_path, "");
+			count++;
+			if (count >= sample_size) {
+				break;
+			}
+		}
+	} catch (...) {
+		// Fall back to find().limit() if $sample is unavailable (e.g., views, older MongoDB).
+		count = 0;
+		field_types.clear();
+		column_name_to_mongo_path.clear();
+		mongocxx::options::find opts;
+		opts.limit(sample_size);
+		auto cursor = collection.find({}, opts);
+		for (const auto &doc : cursor) {
+			CollectFieldPaths(doc, "", 0, field_types, column_name_to_mongo_path, "");
+			count++;
+			if (count >= sample_size) {
+				break;
+			}
 		}
 	}
 

--- a/src/mongo_table_function.cpp
+++ b/src/mongo_table_function.cpp
@@ -608,6 +608,9 @@ void MongoScanFunction(ClientContext &context, TableFunctionInput &data_p, DataC
 			++(*state.current);
 			count++;
 		}
+		for (idx_t col_idx = 0; col_idx < output.ColumnCount(); col_idx++) {
+			MongoSetVectorSize(output.data[col_idx], count);
+		}
 		output.SetCardinality(count);
 		if (*state.current == *state.end) {
 			state.finished = true;
@@ -655,6 +658,7 @@ void MongoScanFunction(ClientContext &context, TableFunctionInput &data_p, DataC
 		vec.SetVectorType(VectorType::FLAT_VECTOR);
 		MongoFlatVectorGetDataMutable<int64_t>(vec)[0] = 0;
 		FlatVector::SetNull(vec, 0, false);
+		MongoSetVectorSize(vec, 1);
 		output.SetCardinality(1);
 		state.finished = true;
 		return;
@@ -691,6 +695,9 @@ void MongoScanFunction(ClientContext &context, TableFunctionInput &data_p, DataC
 		// effectively dropping this row from the output
 	}
 
+	for (idx_t col_idx = 0; col_idx < output.ColumnCount(); col_idx++) {
+		MongoSetVectorSize(output.data[col_idx], count);
+	}
 	output.SetCardinality(count);
 
 	if (state.current && state.end && *state.current == *state.end) {


### PR DESCRIPTION
## Summary
- Schema inference previously used `find().limit(100)`, which returns the first 100 documents in natural (insertion) order. Fields that only exist on some documents — such as completion timestamps that are only set when a case is closed — could be entirely absent from the sample and never appear in the inferred schema.
- Switched to MongoDB's `$sample` aggregation stage for random sampling, which draws documents from across the entire collection and dramatically improves field discovery for heterogeneous schemas.
- Falls back to the old `find().limit()` approach if `$sample` is unavailable (e.g., views or MongoDB < 3.2).

Fixes #30