### PR TITLE
fix: deduplicate case-insensitive column names during schema inference

### DIFF
--- a/src/include/mongo_compat.hpp
+++ b/src/include/mongo_compat.hpp
@@ -24,6 +24,21 @@
 #define DUCKDB_MAIN_VECTOR_API 1
 #endif
 
+#ifdef DUCKDB_MAIN_VECTOR_API
+#include "duckdb/planner/filter/expression_filter.hpp"
+// DuckDB main: bound_comparison_expression.hpp is transitively included above.
+#else
+// DuckDB v1.5.x: include explicitly so MongoIsComparisonExpr / MongoComparisonLeft/Right are available.
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#endif
+
+// DuckDB main made BoundSimpleFunction::name protected; use GetName() accessor.
+#ifdef DUCKDB_MAIN_VECTOR_API
+#define MONGO_FUNCTION_NAME(func) ((func).GetName())
+#else
+#define MONGO_FUNCTION_NAME(func) ((func).name)
+#endif
+
 namespace duckdb {
 
 // Check if a vector has an auxiliary buffer.
@@ -67,6 +82,42 @@ inline void MongoVectorReferenceSingleValue(Vector &vec, const Value &val) {
 inline void MongoSetVectorSize(Vector &vec, idx_t size) {
 #ifdef DUCKDB_MAIN_VECTOR_API
 	FlatVector::SetSize(vec, size);
+#endif
+}
+
+// Copy a single TableFilter (DuckDB main removed TableFilter::Copy(); only ExpressionFilter::Copy() remains).
+inline unique_ptr<TableFilter> MongoCopyFilter(const TableFilter &filter) {
+#ifdef DUCKDB_MAIN_VECTOR_API
+	auto &ef = static_cast<const ExpressionFilter &>(filter);
+	return ef.Copy();
+#else
+	return filter.Copy();
+#endif
+}
+
+// Cross-version comparison expression helpers.
+// DuckDB main: comparisons are BoundFunctionExpression; v1.5.x: BoundComparisonExpression.
+inline bool MongoIsComparisonExpr(const Expression &expr) {
+#ifdef DUCKDB_MAIN_VECTOR_API
+	return BoundComparisonExpression::IsComparison(expr);
+#else
+	return expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON;
+#endif
+}
+
+inline const Expression &MongoComparisonLeft(const Expression &expr) {
+#ifdef DUCKDB_MAIN_VECTOR_API
+	return BoundComparisonExpression::Left(expr.Cast<BoundFunctionExpression>());
+#else
+	return *expr.Cast<BoundComparisonExpression>().left;
+#endif
+}
+
+inline const Expression &MongoComparisonRight(const Expression &expr) {
+#ifdef DUCKDB_MAIN_VECTOR_API
+	return BoundComparisonExpression::Right(expr.Cast<BoundFunctionExpression>());
+#else
+	return *expr.Cast<BoundComparisonExpression>().right;
 #endif
 }
 

--- a/src/include/mongo_compat.hpp
+++ b/src/include/mongo_compat.hpp
@@ -4,16 +4,11 @@
 // Uses __has_include to detect the target DuckDB version at compile time.
 
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/planner/table_filter.hpp"
 
 // FlatVector was moved to a separate header on DuckDB main.
 #if __has_include("duckdb/common/vector/flat_vector.hpp")
 #include "duckdb/common/vector/flat_vector.hpp"
-#endif
-
-// --- ExpressionFilter detection ---
-// DuckDB main wraps all scan filters in ExpressionFilter; v1.5.x uses ConstantFilter directly.
-#if __has_include("duckdb/planner/filter/expression_filter.hpp")
-#define DUCKDB_HAS_EXPRESSION_FILTER 1
 #endif
 
 // --- Vector API compatibility ---

--- a/src/mongo_expr_pushdown.cpp
+++ b/src/mongo_expr_pushdown.cpp
@@ -172,7 +172,7 @@ static bool ValidateFunctionSignature(const BoundFunctionExpression &func_expr, 
 }
 
 static bool IsSafeMongoFunction(const BoundFunctionExpression &func_expr) {
-	const MongoFunctionMapping *mapping = FindFunctionMapping(func_expr.function.name);
+	const MongoFunctionMapping *mapping = FindFunctionMapping(MONGO_FUNCTION_NAME(func_expr.function));
 	if (!mapping) {
 		return false;
 	}
@@ -190,15 +190,16 @@ static bool IsSafeMongoFunction(const BoundFunctionExpression &func_expr) {
 }
 
 static bool IsSafeMongoExpr(const Expression &expr) {
-	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
+	if (!MongoIsComparisonExpr(expr)) {
 		return false;
 	}
-	auto &comp_expr = expr.Cast<BoundComparisonExpression>();
-	if (comp_expr.left && comp_expr.left->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-		return IsSafeMongoFunction(comp_expr.left->Cast<BoundFunctionExpression>());
+	const Expression &left = MongoComparisonLeft(expr);
+	const Expression &right = MongoComparisonRight(expr);
+	if (left.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		return IsSafeMongoFunction(left.Cast<BoundFunctionExpression>());
 	}
-	if (comp_expr.right && comp_expr.right->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-		return IsSafeMongoFunction(comp_expr.right->Cast<BoundFunctionExpression>());
+	if (right.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		return IsSafeMongoFunction(right.Cast<BoundFunctionExpression>());
 	}
 	return false;
 }
@@ -207,7 +208,7 @@ static bool IsSafeMongoExpr(const Expression &expr) {
 static bool ConvertFunctionToMongoExpr(const BoundFunctionExpression &func_expr, const vector<string> &column_names,
                                        const unordered_map<string, string> &column_name_to_mongo_path,
                                        bsoncxx::builder::basic::document &result_builder) {
-	const string &func_name = func_expr.function.name;
+	const string func_name = MONGO_FUNCTION_NAME(func_expr.function);
 
 	// Find function mapping
 	const MongoFunctionMapping *mapping = FindFunctionMapping(func_name);
@@ -259,13 +260,12 @@ static bool ConvertFunctionToMongoExpr(const BoundFunctionExpression &func_expr,
 }
 
 static bool IsSimpleColumnToConstantComparison(const Expression &expr) {
-	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
+	if (!MongoIsComparisonExpr(expr)) {
 		return false;
 	}
-	auto &comp_expr = expr.Cast<BoundComparisonExpression>();
 
-	const Expression *left_expr = comp_expr.left.get();
-	const Expression *right_expr = comp_expr.right.get();
+	const Expression *left_expr = &MongoComparisonLeft(expr);
+	const Expression *right_expr = &MongoComparisonRight(expr);
 
 	// Unwrap CAST on left side
 	while (left_expr->GetExpressionClass() == ExpressionClass::BOUND_CAST) {
@@ -313,13 +313,11 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 		}
 	}
 
-	switch (expr.GetExpressionClass()) {
-	case ExpressionClass::BOUND_COMPARISON: {
-		auto &comp_expr = expr.Cast<BoundComparisonExpression>();
-
-		// Unwrap CAST expressions on both sides to get to underlying expressions
-		const Expression *left_expr = comp_expr.left.get();
-		const Expression *right_expr = comp_expr.right.get();
+	// Use if/else so comparison detection works across DuckDB versions (comparisons are
+	// BoundComparisonExpression in v1.5.x and BoundFunctionExpression in DuckDB main).
+	if (MongoIsComparisonExpr(expr)) {
+		const Expression *left_expr = &MongoComparisonLeft(expr);
+		const Expression *right_expr = &MongoComparisonRight(expr);
 
 		// Unwrap CAST on left side
 		while (left_expr->GetExpressionClass() == ExpressionClass::BOUND_CAST) {
@@ -339,16 +337,11 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 		bool left_is_function = left_expr->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION;
 		bool right_is_function = right_expr->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION;
 
-		// Skip simple column-to-constant comparisons (e.g., age > 25)
-		// These should be handled by TableFilter conversion, which produces faster MongoDB native queries
-		// (e.g., {age: {$gt: 25}}) that can use indexes efficiently, rather than slower $expr queries
-		// (e.g., {$expr: {$gt: ["$age", 25]}}) which cannot use indexes as effectively.
 		if (left_is_column && right_is_constant && !left_is_function && !right_is_function) {
 			return false;
 		}
 
-		// Handle complex comparisons: column-to-column, function calls, etc.
-		ExpressionType comp_type = MONGO_EXPR_TYPE(comp_expr);
+		ExpressionType comp_type = expr.GetExpressionType();
 		string mongo_op;
 		switch (comp_type) {
 		case ExpressionType::COMPARE_GREATERTHAN:
@@ -373,11 +366,9 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 			return false;
 		}
 
-		// Convert left and right sides to MongoDB expressions (using unwrapped expressions)
 		bsoncxx::builder::basic::array args_array;
 		bsoncxx::builder::basic::document left_expr_doc;
 
-		// Convert left side (using unwrapped expression)
 		string left_path = GetMongoPathFromExpression(*left_expr, column_names, column_name_to_mongo_path);
 		if (!left_path.empty()) {
 			args_array.append(left_path);
@@ -391,11 +382,8 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 			return false;
 		}
 
-		// Convert right side (using unwrapped expression)
 		if (right_expr->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
 			auto &right_const = right_expr->Cast<BoundConstantExpression>();
-			// Cast constant to match left expression type if needed
-			// This handles cases like YEAR() returning BIGINT but constant being INTEGER
 			Value const_val = right_const.value;
 			if (MONGO_EXPR_RETURN_TYPE(*left_expr) != const_val.type()) {
 				Value casted_val;
@@ -404,14 +392,12 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 					BoundConstantExpression casted_const(casted_val);
 					AppendConstantToBSONArray(casted_const, args_array);
 				} else {
-					// Cast failed - use original value
 					AppendConstantToBSONArray(right_const, args_array);
 				}
 			} else {
 				AppendConstantToBSONArray(right_const, args_array);
 			}
 		} else {
-			// Try to get MongoDB path (handles CAST-wrapped column references)
 			string right_path = GetMongoPathFromExpression(*right_expr, column_names, column_name_to_mongo_path);
 			if (!right_path.empty()) {
 				args_array.append(right_path);
@@ -427,17 +413,13 @@ static bool ConvertExpressionToMongoExpr(const Expression &expr, const vector<st
 			}
 		}
 
-		// Build comparison expression: { $mongo_op: [left_expr, right_expr] }
 		result_builder.append(bsoncxx::builder::basic::kvp(mongo_op, args_array.extract()));
 		return true;
-	}
-	case ExpressionClass::BOUND_FUNCTION: {
+	} else if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
 		auto &func_expr = expr.Cast<BoundFunctionExpression>();
 		return ConvertFunctionToMongoExpr(func_expr, column_names, column_name_to_mongo_path, result_builder);
 	}
-	default:
-		return false;
-	}
+	return false;
 }
 
 } // namespace

--- a/src/mongo_filter_pushdown.cpp
+++ b/src/mongo_filter_pushdown.cpp
@@ -171,48 +171,55 @@ static void AppendValueToDocument(bsoncxx::builder::basic::document &doc_builder
 	}
 }
 
+// Build a comparison MongoDB filter document from a comparison type and constant value.
+// Used by both the legacy ConstantFilter path and the DuckDB main ExpressionFilter path.
+static bsoncxx::document::value BuildComparisonFilterDoc(ExpressionType cmp_type, const Value &constant,
+                                                         const string &column_name, const LogicalType &column_type,
+                                                         const unordered_set<string> &objectid_columns) {
+	bsoncxx::builder::basic::document doc;
+	string mongo_op;
+	switch (cmp_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		AppendValueToDocument(doc, column_name, constant, column_type, column_name, objectid_columns);
+		break;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		mongo_op = "$ne";
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		mongo_op = "$lt";
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		mongo_op = "$lte";
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		mongo_op = "$gt";
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		mongo_op = "$gte";
+		break;
+	default:
+		return doc.extract();
+	}
+	if (!mongo_op.empty()) {
+		bsoncxx::builder::basic::document op_doc;
+		AppendValueToDocument(op_doc, mongo_op, constant, column_type, column_name, objectid_columns);
+		doc.append(bsoncxx::builder::basic::kvp(column_name, op_doc.extract()));
+	}
+	return doc.extract();
+}
+
 static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &filter, const string &column_name,
                                                            const LogicalType &column_type,
                                                            const unordered_set<string> &objectid_columns) {
 	bsoncxx::builder::basic::document doc;
 
 	switch (filter.filter_type) {
+#ifndef DUCKDB_MAIN_VECTOR_API
+	// DuckDB v1.5.x uses typed TableFilter subclasses. DuckDB main uses ExpressionFilter for all scan filters.
 	case TableFilterType::CONSTANT_COMPARISON: {
 		const auto &constant_filter = filter.Cast<ConstantFilter>();
-		string mongo_op;
-
-		switch (constant_filter.comparison_type) {
-		case ExpressionType::COMPARE_EQUAL:
-			AppendValueToDocument(doc, column_name, constant_filter.constant, column_type, column_name,
-			                      objectid_columns);
-			break;
-		case ExpressionType::COMPARE_NOTEQUAL:
-			mongo_op = "$ne";
-			break;
-		case ExpressionType::COMPARE_LESSTHAN:
-			mongo_op = "$lt";
-			break;
-		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-			mongo_op = "$lte";
-			break;
-		case ExpressionType::COMPARE_GREATERTHAN:
-			mongo_op = "$gt";
-			break;
-		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-			mongo_op = "$gte";
-			break;
-		default:
-			// Unsupported comparison type, return empty filter
-			return doc.extract();
-		}
-
-		if (!mongo_op.empty()) {
-			bsoncxx::builder::basic::document op_doc;
-			AppendValueToDocument(op_doc, mongo_op, constant_filter.constant, column_type, column_name,
-			                      objectid_columns);
-			doc.append(bsoncxx::builder::basic::kvp(column_name, op_doc.extract()));
-		}
-		break;
+		return BuildComparisonFilterDoc(constant_filter.comparison_type, constant_filter.constant, column_name,
+		                                column_type, objectid_columns);
 	}
 	case TableFilterType::IN_FILTER: {
 		const auto &in_filter = filter.Cast<InFilter>();
@@ -239,15 +246,12 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		break;
 	}
 	case TableFilterType::CONJUNCTION_AND: {
-		// For AND filters, combine conditions on the same column
 		const auto &conj_filter = static_cast<const ConjunctionFilter &>(filter);
 		bsoncxx::builder::basic::document merged_doc;
 		for (const auto &child_filter : conj_filter.child_filters) {
 			auto child_doc = ConvertSingleFilterToMongo(*child_filter, column_name, column_type, objectid_columns);
-			// Extract conditions from child_doc and merge
 			for (auto it = child_doc.view().begin(); it != child_doc.view().end(); ++it) {
 				if (it->key() == column_name && it->type() == bsoncxx::type::k_document) {
-					// Merge nested document conditions
 					for (auto nested_it = it->get_document().value.begin(); nested_it != it->get_document().value.end();
 					     ++nested_it) {
 						merged_doc.append(bsoncxx::builder::basic::kvp(
@@ -263,7 +267,6 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		break;
 	}
 	case TableFilterType::CONJUNCTION_OR: {
-		// For OR filters, use $or with each child condition
 		const auto &conj_filter = static_cast<const ConjunctionFilter &>(filter);
 		bsoncxx::builder::basic::array or_array;
 		for (const auto &child_filter : conj_filter.child_filters) {
@@ -276,20 +279,17 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 					continue;
 				}
 			}
-
 			auto child_doc = ConvertSingleFilterToMongo(*child_filter, column_name, column_type, objectid_columns);
 			if (!child_doc.view().empty()) {
 				or_array.append(child_doc.view());
 			}
 		}
-
 		if (!or_array.view().empty()) {
 			doc.append(bsoncxx::builder::basic::kvp("$or", or_array.extract()));
 		}
 		break;
 	}
 	case TableFilterType::STRUCT_EXTRACT: {
-		// StructFilter for nested field access - MongoDB supports via dot notation
 		const auto &struct_filter = filter.Cast<StructFilter>();
 		if (struct_filter.child_filter) {
 			string nested_path = column_name + "." + struct_filter.child_name;
@@ -298,7 +298,6 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		break;
 	}
 	case TableFilterType::OPTIONAL_FILTER: {
-		// OptionalFilter wraps another filter (often IN filters from semi-join pushdown)
 		const auto &opt_filter = filter.Cast<OptionalFilter>();
 		if (opt_filter.child_filter) {
 			return ConvertSingleFilterToMongo(*opt_filter.child_filter, column_name, column_type, objectid_columns);
@@ -306,43 +305,40 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		break;
 	}
 	case TableFilterType::DYNAMIC_FILTER: {
-		// DynamicFilter wraps a runtime-updatable filter.
 		const auto &dyn_filter = filter.Cast<DynamicFilter>();
 		if (!dyn_filter.filter_data || !dyn_filter.filter_data->initialized) {
 			break;
 		}
-#ifdef DUCKDB_MAIN_VECTOR_API
-		// DuckDB main: DynamicFilterData exposes comparison_type and constant directly.
-		ConstantFilter const_filter(dyn_filter.filter_data->comparison_type, dyn_filter.filter_data->constant);
-#else
-		// DuckDB v1.5.x: DynamicFilterData wraps a ConstantFilter.
 		if (!dyn_filter.filter_data->filter) {
 			break;
 		}
-		auto &const_filter = *dyn_filter.filter_data->filter;
-#endif
-		return ConvertSingleFilterToMongo(const_filter, column_name, column_type, objectid_columns);
+		return ConvertSingleFilterToMongo(*dyn_filter.filter_data->filter, column_name, column_type, objectid_columns);
 	}
+#endif // !DUCKDB_MAIN_VECTOR_API
 #ifdef DUCKDB_HAS_EXPRESSION_FILTER
 	case TableFilterType::EXPRESSION_FILTER: {
-		// DuckDB main wraps all scan filters in ExpressionFilter containing a BoundComparisonExpression.
-		// Extract the comparison type and constant, then delegate to the ConstantFilter path.
+		// DuckDB main wraps all scan filters in ExpressionFilter.
 		const auto &expr_filter = filter.Cast<ExpressionFilter>();
 		if (!expr_filter.expr) {
 			break;
 		}
+		// Skip optional/dynamic expression wrappers — we cannot guarantee their value at planning time.
+		if (ExpressionFilter::IsOptionalFilter(filter)) {
+			break;
+		}
 		auto &inner_expr = *expr_filter.expr;
 		// Handle comparison expressions (e.g., col = 5, col > 10).
-		if (inner_expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
-			auto &cmp = inner_expr.Cast<BoundComparisonExpression>();
-			// The constant can be on either side. Identify which side is the constant.
-			Expression *const_side = nullptr;
-			ExpressionType cmp_type = cmp.GetExpressionType();
-			if (cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-				const_side = cmp.right.get();
-			} else if (cmp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-				const_side = cmp.left.get();
-				// Flip the comparison direction when the constant is on the left.
+		// DuckDB main represents comparisons as BoundFunctionExpression; use BoundComparisonExpression helpers.
+		if (BoundComparisonExpression::IsComparison(inner_expr)) {
+			auto &cmp = inner_expr.Cast<BoundFunctionExpression>();
+			const Expression *const_side = nullptr;
+			ExpressionType cmp_type = inner_expr.GetExpressionType();
+			const Expression &right = BoundComparisonExpression::Right(cmp);
+			const Expression &left = BoundComparisonExpression::Left(cmp);
+			if (right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+				const_side = &right;
+			} else if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+				const_side = &left;
 				switch (cmp_type) {
 				case ExpressionType::COMPARE_LESSTHAN:
 					cmp_type = ExpressionType::COMPARE_GREATERTHAN;
@@ -362,15 +358,13 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 			}
 			if (const_side) {
 				auto &const_expr = const_side->Cast<BoundConstantExpression>();
-				ConstantFilter const_filter(cmp_type, const_expr.value);
-				return ConvertSingleFilterToMongo(const_filter, column_name, column_type, objectid_columns);
+				return BuildComparisonFilterDoc(cmp_type, const_expr.value, column_name, column_type, objectid_columns);
 			}
 		}
 		// Handle conjunction expressions (AND / OR).
 		if (inner_expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
 			auto &conj = inner_expr.Cast<BoundConjunctionExpression>();
 			if (conj.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
-				// Recursively convert each child and merge into a single AND document.
 				bsoncxx::builder::basic::document merged_doc;
 				for (auto &child : conj.children) {
 					ExpressionFilter child_ef(child->Copy());
@@ -423,7 +417,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		}
 		break;
 	}
-#endif
+#endif // DUCKDB_HAS_EXPRESSION_FILTER
 	default:
 		break;
 	}

--- a/src/mongo_filter_pushdown.cpp
+++ b/src/mongo_filter_pushdown.cpp
@@ -13,7 +13,9 @@
 #include "duckdb/common/types/timestamp.hpp"
 
 // DuckDB main uses ExpressionFilter wrapping BoundComparisonExpression instead of ConstantFilter.
-#ifdef DUCKDB_HAS_EXPRESSION_FILTER
+// These headers only exist in their current form on DuckDB main (v1.5.x also has expression_filter.hpp
+// but lacks the static helpers IsComparison/Left/Right on BoundComparisonExpression).
+#ifdef DUCKDB_MAIN_VECTOR_API
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
@@ -315,7 +317,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		return ConvertSingleFilterToMongo(*dyn_filter.filter_data->filter, column_name, column_type, objectid_columns);
 	}
 #endif // !DUCKDB_MAIN_VECTOR_API
-#ifdef DUCKDB_HAS_EXPRESSION_FILTER
+#ifdef DUCKDB_MAIN_VECTOR_API
 	case TableFilterType::EXPRESSION_FILTER: {
 		// DuckDB main wraps all scan filters in ExpressionFilter.
 		const auto &expr_filter = filter.Cast<ExpressionFilter>();
@@ -417,7 +419,7 @@ static bsoncxx::document::value ConvertSingleFilterToMongo(const TableFilter &fi
 		}
 		break;
 	}
-#endif // DUCKDB_HAS_EXPRESSION_FILTER
+#endif // DUCKDB_MAIN_VECTOR_API
 	default:
 		break;
 	}

--- a/src/mongo_optimizer.cpp
+++ b/src/mongo_optimizer.cpp
@@ -136,7 +136,7 @@ static bsoncxx::document::value BuildMatchFromExistingFilters(const LogicalGet &
 		MongoForEachFilter(*filters_copy, [&](idx_t proj_idx, TableFilter &filter) {
 			if (proj_idx < col_ids.size()) {
 				idx_t schema_idx = col_ids[proj_idx].GetPrimaryIndex();
-				MongoSetFilter(*remapped_filters, schema_idx, filter.Copy());
+				MongoSetFilter(*remapped_filters, schema_idx, MongoCopyFilter(filter));
 			}
 		});
 		auto *filters_to_use = remapped_filters.get();
@@ -271,7 +271,7 @@ static bool IsSupportedAggregate(const BoundAggregateExpression &aggr, const Log
 		return false;
 	}
 
-	auto fname = StringUtil::Lower(aggr.function.name);
+	auto fname = StringUtil::Lower(MONGO_FUNCTION_NAME(aggr.function));
 	if (fname == "count_star") {
 		out_kind = "count_star";
 		out_child_col = DConstants::INVALID_INDEX;

--- a/src/mongo_schema_inference.cpp
+++ b/src/mongo_schema_inference.cpp
@@ -534,21 +534,43 @@ void InferSchemaFromDocuments(mongocxx::collection &collection, int64_t sample_s
 		column_name_to_mongo_path["_id"] = "_id";    // Map _id to itself
 	}
 
-	// Build column names and types from collected field paths
+	// Build column names and types from collected field paths.
+	// Use case-insensitive deduplication: DuckDB's binder uses a case_insensitive_map for
+	// column names, so "clientFullname" and "ClientFullname" would collide. MongoDB field
+	// names are case-sensitive, so random sampling can yield both variants from the same
+	// logical field — producing an intermittent "duplicate column name" binder error.
+	// When a collision is detected, merge the types and keep the first-seen column name.
+	std::unordered_map<std::string, size_t> lower_name_to_idx; // lowercase name -> index in column_names
+
 	// Ensure _id is always first
 	if (field_types.find("_id") != field_types.end()) {
 		column_names.push_back("_id");
 		LogicalType resolved_type = ResolveTypeConflict(field_types["_id"]);
 		column_types.push_back(resolved_type);
+		lower_name_to_idx["_id"] = 0;
 	}
 
 	// Add all other columns (excluding _id which we already added)
 	for (const auto &pair : field_types) {
-		if (pair.first != "_id") {
-			column_names.push_back(pair.first);
-			LogicalType resolved_type = ResolveTypeConflict(pair.second);
-			column_types.push_back(resolved_type);
+		if (pair.first == "_id") {
+			continue;
 		}
+		std::string lower_name = StringUtil::Lower(pair.first);
+		auto it = lower_name_to_idx.find(lower_name);
+		if (it != lower_name_to_idx.end()) {
+			// Case-insensitive collision: merge types into the existing column entry.
+			size_t existing_idx = it->second;
+			std::vector<LogicalType> merged = {column_types[existing_idx]};
+			for (const auto &t : pair.second) {
+				merged.push_back(t);
+			}
+			column_types[existing_idx] = ResolveTypeConflict(merged);
+			continue;
+		}
+		lower_name_to_idx[lower_name] = column_names.size();
+		column_names.push_back(pair.first);
+		LogicalType resolved_type = ResolveTypeConflict(pair.second);
+		column_types.push_back(resolved_type);
 	}
 
 	// Ensure we have at least one column (should always have _id, but double-check)

--- a/src/mongo_table_function.cpp
+++ b/src/mongo_table_function.cpp
@@ -365,7 +365,7 @@ unique_ptr<LocalTableFunctionState> MongoScanInitLocal(ExecutionContext &context
 		MongoForEachFilter(*input.filters, [&](idx_t col_idx, TableFilter &filter) {
 			auto it = filter_index_map.find(col_idx);
 			if (it != filter_index_map.end()) {
-				MongoSetFilter(*remapped_filters, it->second, filter.Copy());
+				MongoSetFilter(*remapped_filters, it->second, MongoCopyFilter(filter));
 			}
 		});
 

--- a/test/create-mongo-tables.sh
+++ b/test/create-mongo-tables.sh
@@ -493,6 +493,28 @@ db.schema_test_types.insertOne({
   created: 'TIMESTAMP'
 });
 
+// Collection for testing case-variant field name deduplication (issue #35).
+// MongoDB is case-sensitive so 'clientFullname' and 'ClientFullname' are distinct fields.
+// DuckDB is case-insensitive, so inferring both would produce a duplicate column name error.
+// The two documents deliberately use different cases for the same logical field to reproduce
+// the intermittent 'duplicate column name' binder error seen with random $sample results.
+db.case_variant_fields_test.insertMany([
+  {
+    _id: ObjectId('507f1f77bcf86cd799439099'),
+    case_data: {
+      clientFullname: 'John Doe',
+      status: 'active'
+    }
+  },
+  {
+    _id: ObjectId('507f1f77bcf86cd79943909a'),
+    case_data: {
+      ClientFullname: 'Jane Smith',
+      status: 'inactive'
+    }
+  }
+]);
+
 print('Test database created successfully!');
 print('Database: ' + db.getName());
 print('Collections: ' + db.getCollectionNames().join(', '));
@@ -500,7 +522,7 @@ print('Collections: ' + db.getCollectionNames().join(', '));
 
 echo ""
 echo "Test MongoDB database '$MONGO_DB' created successfully!"
-echo "Collections: users, products, orders, decimal_test, empty_collection, type_conflicts, deeply_nested, nested_scalars_test, object_container_test, string_id_test, schema_test_simple, schema_test_nested, schema_test_paths, schema_test_with_id, schema_test_types"
+echo "Collections: users, products, orders, decimal_test, empty_collection, type_conflicts, deeply_nested, nested_scalars_test, object_container_test, string_id_test, schema_test_simple, schema_test_nested, schema_test_paths, schema_test_with_id, schema_test_types, case_variant_fields_test"
 echo ""
 
 # Export environment variables for tests

--- a/test/sql/attach/catalog_operations.test
+++ b/test/sql/attach/catalog_operations.test
@@ -30,6 +30,7 @@ USE mongo_db.duckdb_mongo_test;
 query I
 SHOW TABLES;
 ----
+case_variant_fields_test
 decimal_test
 deeply_nested
 empty_collection
@@ -58,6 +59,7 @@ query III
 SELECT database, schema, name FROM (SHOW ALL TABLES) ORDER BY database, name;
 ----
 memory	main	test_memory_table
+mongo_db	duckdb_mongo_test	case_variant_fields_test
 mongo_db	duckdb_mongo_test	decimal_test
 mongo_db	duckdb_mongo_test	deeply_nested
 mongo_db	duckdb_mongo_test	empty_collection
@@ -124,10 +126,10 @@ users
 
 # Total collections in test database
 query I
-SELECT COUNT(*) FROM duckdb_views() 
+SELECT COUNT(*) FROM duckdb_views()
 WHERE database_name = 'mongo_db' AND schema_name = 'duckdb_mongo_test';
 ----
-16
+17
 
 query I
 SELECT column_name FROM duckdb_columns() 

--- a/test/sql/cache/clear_cache.test
+++ b/test/sql/cache/clear_cache.test
@@ -41,27 +41,28 @@ ATTACH 'host=localhost port=27017 database=duckdb_mongo_test' AS test_mongo (TYP
 # Query collections initially - this populates the collection cache
 # Count only tables in the specific schema to avoid dependencies on other attached databases
 query I
-SELECT COUNT(*) FROM information_schema.tables 
-WHERE table_catalog = 'test_mongo' 
+SELECT COUNT(*) FROM information_schema.tables
+WHERE table_catalog = 'test_mongo'
   AND table_schema = 'duckdb_mongo_test';
 ----
-16
+17
 
 # Query collections again - should use cached data
 query I
-SELECT COUNT(*) FROM information_schema.tables 
-WHERE table_catalog = 'test_mongo' 
+SELECT COUNT(*) FROM information_schema.tables
+WHERE table_catalog = 'test_mongo'
   AND table_schema = 'duckdb_mongo_test';
 ----
-16
+17
 
 # Get list of collections (this uses cached collection names)
 query T
-SELECT table_name FROM information_schema.tables 
-WHERE table_catalog = 'test_mongo' 
+SELECT table_name FROM information_schema.tables
+WHERE table_catalog = 'test_mongo'
   AND table_schema = 'duckdb_mongo_test'
 ORDER BY table_name;
 ----
+case_variant_fields_test
 decimal_test
 deeply_nested
 empty_collection
@@ -89,19 +90,20 @@ SELECT * FROM mongo_clear_cache();
 
 # Query collections again - should fetch fresh data from MongoDB
 query I
-SELECT COUNT(*) FROM information_schema.tables 
-WHERE table_catalog = 'test_mongo' 
+SELECT COUNT(*) FROM information_schema.tables
+WHERE table_catalog = 'test_mongo'
   AND table_schema = 'duckdb_mongo_test';
 ----
-16
+17
 
 # Verify we get the same collections (proving fresh data was fetched, not stale cache)
 query T
-SELECT table_name FROM information_schema.tables 
-WHERE table_catalog = 'test_mongo' 
+SELECT table_name FROM information_schema.tables
+WHERE table_catalog = 'test_mongo'
   AND table_schema = 'duckdb_mongo_test'
 ORDER BY table_name;
 ----
+case_variant_fields_test
 decimal_test
 deeply_nested
 empty_collection

--- a/test/sql/schema/case_variant_fields.test
+++ b/test/sql/schema/case_variant_fields.test
@@ -1,0 +1,31 @@
+# name: test/sql/schema/case_variant_fields.test
+# description: Test that case-variant field names do not produce "duplicate column name" binder errors
+# group: [schema]
+#
+# Reproduces issue #35: MongoDB field names are case-sensitive, so "clientFullname" and
+# "ClientFullname" are distinct fields. DuckDB column names are case-insensitive, so when
+# $sample returns documents with both variants the binder would throw:
+#   Binder Error: table "mongo_scan" has duplicate column name "case_data_clientFullname"
+# The fix deduplicates column names case-insensitively during schema inference.
+
+require mongo
+
+require-env MONGODB_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'host=localhost port=27017 dbname=duckdb_mongo_test' AS mongo_test (TYPE MONGO);
+
+# Querying a collection where one doc has case_data.clientFullname and another has
+# case_data.ClientFullname must not crash with a "duplicate column name" binder error.
+query I
+SELECT COUNT(*) FROM mongo_test.case_variant_fields_test;
+----
+2
+
+# The deduplication keeps one case variant for the column. DuckDB resolves column
+# references case-insensitively, so any casing works in the query. Only the document
+# whose case_data field matches the kept MongoDB path will return a non-NULL value.
+query I
+SELECT COUNT(*) FROM mongo_test.case_variant_fields_test WHERE case_data_clientfullname IS NOT NULL;
+----
+1

--- a/test/sql/schema/case_variant_fields.test
+++ b/test/sql/schema/case_variant_fields.test
@@ -1,6 +1,7 @@
 # name: test/sql/schema/case_variant_fields.test
 # description: Test that case-variant field names do not produce "duplicate column name" binder errors
 # group: [schema]
+
 #
 # Reproduces issue #35: MongoDB field names are case-sensitive, so "clientFullname" and
 # "ClientFullname" are distinct fields. DuckDB column names are case-insensitive, so when


### PR DESCRIPTION
DuckDB's binder uses a `case_insensitive_map_t` for column names, but MongoDB field names are case-sensitive. When `$sample` returns documents where the same logical field appears with different casing in different documents (e.g., `case_data.clientFullname` vs `case_data.ClientFullname`), `InferSchemaFromDocuments` creates two separate entries in its case-sensitive `field_types` map — both get pushed to `column_names`, and DuckDB throws an intermittent binder error: `Binder Error: table "mongo_scan" has duplicate column name "case_data_clientFullname"`.

- **Fix**: Added a `lower_name_to_idx` tracker (keyed by `StringUtil::Lower(name)`) when building `column_names` from `field_types`. On a case-insensitive collision, types are merged into the first-seen entry and the duplicate name is skipped.
- **Test**: New `case_variant_fields_test` collection in `create-mongo-tables.sh` with two documents using `clientFullname` / `ClientFullname` to reproduce the failure, plus a corresponding SQL test that verifies no crash and correct row count.

Fixes #35