### PR TITLE
feat: allow mongo_scan to accept a secret name as connection argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,18 @@ WHERE unnest.product = 'Mouse';
 You can also use the `mongo_scan` table function directly without attaching:
 
 ```sql
--- Basic usage
+-- Basic usage with a raw URI
 SELECT * FROM mongo_scan('mongodb://localhost:27017', 'mydb', 'mycollection');
+
+-- Using a named secret (recommended for Atlas / SRV connections)
+CREATE SECRET my_atlas (
+    TYPE MONGO,
+    HOST 'cluster0.xxxxx.mongodb.net',
+    USER 'myuser',
+    PASSWORD 'mypassword',
+    SRV 'true'
+);
+SELECT * FROM mongo_scan('my_atlas', 'mydb', 'mycollection');
 
 -- With filter and sample size
 SELECT * FROM mongo_scan('mongodb://localhost:27017', 'mydb', 'mycollection', 
@@ -337,7 +347,7 @@ SELECT * FROM mongo_scan('mongodb://localhost:27017', 'mydb', 'mycollection',
 ```
 
 **Parameters:**
-- `connection_string`: MongoDB connection string
+- `connection_string`: MongoDB connection string (`mongodb://` or `mongodb+srv://`) **or** a secret name created with `CREATE SECRET (TYPE MONGO, ...)`
 - `database`: MongoDB database name
 - `collection`: MongoDB collection name
 - `filter` (optional): MongoDB query filter as JSON string (e.g., `'{"status": "active"}'`)

--- a/src/mongo_table_function.cpp
+++ b/src/mongo_table_function.cpp
@@ -88,8 +88,8 @@ unique_ptr<FunctionData> MongoScanBind(ClientContext &context, TableFunctionBind
 
 	// The first argument is either a raw MongoDB URI or a secret name.
 	// If it looks like a URI, use it directly; otherwise treat it as a secret name.
-	bool is_uri = StringUtil::StartsWith(first_arg, "mongodb://") ||
-	              StringUtil::StartsWith(first_arg, "mongodb+srv://");
+	bool is_uri =
+	    StringUtil::StartsWith(first_arg, "mongodb://") || StringUtil::StartsWith(first_arg, "mongodb+srv://");
 	if (is_uri) {
 		result->connection_string = first_arg;
 	} else {

--- a/src/mongo_table_function.cpp
+++ b/src/mongo_table_function.cpp
@@ -2,6 +2,7 @@
 #include "mongo_instance.hpp"
 #include "mongo_filter_pushdown.hpp"
 #include "mongo_compat.hpp"
+#include "mongo_secrets.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/time.hpp"
@@ -81,9 +82,26 @@ unique_ptr<FunctionData> MongoScanBind(ClientContext &context, TableFunctionBind
 		    "mongo_scan requires at least 3 arguments: connection_string, database, collection");
 	}
 
-	result->connection_string = input.inputs[0].GetValue<string>();
+	string first_arg = input.inputs[0].GetValue<string>();
 	result->database_name = input.inputs[1].GetValue<string>();
 	result->collection_name = input.inputs[2].GetValue<string>();
+
+	// The first argument is either a raw MongoDB URI or a secret name.
+	// If it looks like a URI, use it directly; otherwise treat it as a secret name.
+	bool is_uri = StringUtil::StartsWith(first_arg, "mongodb://") ||
+	              StringUtil::StartsWith(first_arg, "mongodb+srv://");
+	if (is_uri) {
+		result->connection_string = first_arg;
+	} else {
+		auto secret_entry = GetMongoSecret(context, first_arg);
+		if (!secret_entry) {
+			throw BinderException("Secret with name \"%s\" not found. Pass a MongoDB URI (mongodb:// or "
+			                      "mongodb+srv://) or a valid secret name.",
+			                      first_arg);
+		}
+		const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+		result->connection_string = BuildMongoConnectionString(kv_secret, "");
+	}
 
 	// Parse named parameters
 	if (input.named_parameters.find("filter") != input.named_parameters.end()) {


### PR DESCRIPTION
Closes #37.

`mongo_scan`'s first argument now accepts either a raw MongoDB URI (`mongodb://` or `mongodb+srv://`) or a named secret created with `CREATE SECRET (TYPE MONGO, ...)`. When a secret name is passed, the connection string is built via the existing `BuildMongoConnectionString` helper, giving `mongo_scan` the same SRV, TLS, and auth support already available through `ATTACH`.

Fully backward-compatible: existing calls with raw URIs are unchanged.

## Usage

```sql
-- Create a secret (e.g., for MongoDB Atlas with SRV)
CREATE SECRET my_atlas (
    TYPE MONGO,
    HOST 'cluster0.xxxxx.mongodb.net',
    USER 'myuser',
    PASSWORD 'mypassword',
    SRV 'true'
);

-- Use the secret name directly in mongo_scan
SELECT * FROM mongo_scan('my_atlas', 'mydb', 'mycollection');

-- Raw URIs still work as before
SELECT * FROM mongo_scan('mongodb+srv://myuser:mypassword@cluster0.xxxxx.mongodb.net', 'mydb', 'mycollection');
```