### PR TITLE
fix: mongo_scan secret support for persistent secrets and special-char passwords

### DIFF
--- a/src/mongo_secrets.cpp
+++ b/src/mongo_secrets.cpp
@@ -2,8 +2,24 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/catalog/catalog_transaction.hpp"
+#include <iomanip>
+#include <sstream>
 
 namespace duckdb {
+
+static string PercentEncodeUserInfo(const string &s) {
+	std::ostringstream out;
+	out << std::hex << std::uppercase;
+	for (unsigned char c : s) {
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
+		    c == '_' || c == '~') {
+			out << c;
+		} else {
+			out << '%' << std::setw(2) << std::setfill('0') << static_cast<int>(c);
+		}
+	}
+	return out.str();
+}
 
 unique_ptr<SecretEntry> GetMongoSecret(ClientContext &context, const string &secret_name) {
 	auto &secret_manager = SecretManager::Get(context);
@@ -47,9 +63,9 @@ string BuildMongoConnectionString(const KeyValueSecret &kv_secret, const string 
 	// Build MongoDB connection string
 	string connection_string = use_srv ? "mongodb+srv://" : "mongodb://";
 	if (!user.empty() || !password.empty()) {
-		connection_string += user;
+		connection_string += PercentEncodeUserInfo(user);
 		if (!password.empty()) {
-			connection_string += ":" + password;
+			connection_string += ":" + PercentEncodeUserInfo(password);
 		}
 		connection_string += "@";
 	}

--- a/src/mongo_secrets.cpp
+++ b/src/mongo_secrets.cpp
@@ -24,16 +24,7 @@ static string PercentEncodeUserInfo(const string &s) {
 unique_ptr<SecretEntry> GetMongoSecret(ClientContext &context, const string &secret_name) {
 	auto &secret_manager = SecretManager::Get(context);
 	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
-	// FIXME: this should be adjusted once the `GetSecretByName` API supports this use case
-	auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "memory");
-	if (secret_entry) {
-		return secret_entry;
-	}
-	secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "local_file");
-	if (secret_entry) {
-		return secret_entry;
-	}
-	return nullptr;
+	return secret_manager.GetSecretByName(transaction, secret_name);
 }
 
 string BuildMongoConnectionString(const KeyValueSecret &kv_secret, const string &attach_path) {


### PR DESCRIPTION
## Summary

Two bugs in secret-based connection handling, both of which can cause \`mongo_scan('secret_name', ...)\` to fail:

- **Percent-encode credentials in URI**: \`BuildMongoConnectionString\` now percent-encodes username and password per RFC 3986. Credentials containing special characters like \`@\`, \`:\`, \`/\`, \`?\`, or \`#\` previously produced a malformed URI, causing the MongoDB driver to throw \`Invalid URI Schema, expecting 'mongodb://' or 'mongodb+srv://'\`.

- **Search all secret storage backends**: \`GetMongoSecret\` previously hard-coded lookups to "memory" and "local\_file" storage, so persistent secrets (created with \`CREATE PERSISTENT SECRET\` or stored in a file-backed DuckDB) were silently not found. Passing an empty storage string to \`GetSecretByName\` makes it iterate all registered backends. This also removes the long-standing FIXME comment.

Closes #40